### PR TITLE
fix(android): enable long scan forcing for sustained BLE scans

### DIFF
--- a/android/src/main/java/ee/forgr/plugin/capacitor_ibeacon/CapacitorIbeaconPlugin.java
+++ b/android/src/main/java/ee/forgr/plugin/capacitor_ibeacon/CapacitorIbeaconPlugin.java
@@ -30,6 +30,7 @@ import org.altbeacon.beacon.Identifier;
 import org.altbeacon.beacon.MonitorNotifier;
 import org.altbeacon.beacon.RangeNotifier;
 import org.altbeacon.beacon.Region;
+import org.altbeacon.beacon.Settings;
 
 @CapacitorPlugin(
     name = "CapacitorIbeacon",
@@ -65,6 +66,9 @@ public class CapacitorIbeaconPlugin extends Plugin implements BeaconConsumer {
         // Configure for background scanning - enable long-running scanning mode
         // This is critical for beacon detection when app is in background
         beaconManager.setEnableScheduledScanJobs(false);
+
+        // Prevent Android from downgrading long-running BLE scans to opportunistic mode
+        beaconManager.adjustSettings(new Settings.Builder().setLongScanForcingEnabled(true).build());
 
         // Configure background scan periods (in milliseconds)
         // Default background scan: 10 seconds scan, 5 minutes between scans


### PR DESCRIPTION
## Summary
- Enable AltBeacon `longScanForcingEnabled` when initializing the beacon manager
- Prevents Android from downgrading BLE scans longer than ~10 minutes to opportunistic mode, which stops iBeacon detection

Fixes #27

## Test plan
- [x] `bun run verify:android` passes locally
- [ ] Run a long-running ranging session (>10 minutes) on Android and confirm beacons keep being detected
- [ ] Confirm logcat no longer shows "Allowing a long running scan to be stopped by the OS"


Made with [Cursor](https://cursor.com)