### PR TITLE
fix(android): defer beacon service bind until scanning starts

### DIFF
--- a/android/src/main/java/ee/forgr/plugin/capacitor_ibeacon/CapacitorIbeaconPlugin.java
+++ b/android/src/main/java/ee/forgr/plugin/capacitor_ibeacon/CapacitorIbeaconPlugin.java
@@ -143,7 +143,7 @@ public class CapacitorIbeaconPlugin extends Plugin implements BeaconConsumer {
 
     @Override
     public void onBeaconServiceConnect() {
-        beaconManagerBound = true;
+        // beaconManagerBound is already set synchronously wherever bind() is called.
     }
 
     @Override
@@ -719,6 +719,9 @@ public class CapacitorIbeaconPlugin extends Plugin implements BeaconConsumer {
         if (backgroundModeEnabled) {
             enableForegroundServiceIfNeeded();
         }
+        // Set before bind() - AltBeacon is synchronously bound inside bind() itself, not only
+        // once onBeaconServiceConnect() fires.
+        beaconManagerBound = true;
         beaconManager.bind(this);
     }
 
@@ -748,6 +751,7 @@ public class CapacitorIbeaconPlugin extends Plugin implements BeaconConsumer {
             disableForegroundServiceIfNeeded();
         }
         if (wasBound) {
+            beaconManagerBound = true;
             beaconManager.bind(this);
             for (Region region : monitoredRegions.values()) {
                 beaconManager.startMonitoring(region);

--- a/android/src/main/java/ee/forgr/plugin/capacitor_ibeacon/CapacitorIbeaconPlugin.java
+++ b/android/src/main/java/ee/forgr/plugin/capacitor_ibeacon/CapacitorIbeaconPlugin.java
@@ -570,9 +570,7 @@ public class CapacitorIbeaconPlugin extends Plugin implements BeaconConsumer {
         Boolean enabled = call.getBoolean("enabled", true);
         boolean wantBackground = enabled != null && enabled;
         try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && wantBackground != foregroundServiceEnabled) {
-                reconfigureForegroundService(wantBackground);
-            }
+            ensureForegroundServiceMatches(wantBackground);
             setBackgroundModeEnabled(wantBackground);
             call.resolve();
         } catch (Exception e) {
@@ -713,11 +711,9 @@ public class CapacitorIbeaconPlugin extends Plugin implements BeaconConsumer {
     }
 
     private void bindIfNeeded() {
+        ensureForegroundServiceMatches(backgroundModeEnabled);
         if (beaconManagerBound || beaconManager == null) {
             return;
-        }
-        if (backgroundModeEnabled) {
-            enableForegroundServiceIfNeeded();
         }
         // Set before bind() - AltBeacon is synchronously bound inside bind() itself, not only
         // once onBeaconServiceConnect() fires.
@@ -735,6 +731,14 @@ public class CapacitorIbeaconPlugin extends Plugin implements BeaconConsumer {
             return;
         }
         beaconManager.setBackgroundMode(enabled && isInBackground);
+    }
+
+    // Covers both a fresh bind and a later call (e.g. a per-region enableBackgroundMode option)
+    // that raises the requirement while already bound.
+    private void ensureForegroundServiceMatches(boolean wantForegroundService) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && wantForegroundService != foregroundServiceEnabled) {
+            reconfigureForegroundService(wantForegroundService);
+        }
     }
 
     // enableForegroundServiceScanning()/disableForegroundServiceScanning() may only be called

--- a/android/src/main/java/ee/forgr/plugin/capacitor_ibeacon/CapacitorIbeaconPlugin.java
+++ b/android/src/main/java/ee/forgr/plugin/capacitor_ibeacon/CapacitorIbeaconPlugin.java
@@ -80,8 +80,7 @@ public class CapacitorIbeaconPlugin extends Plugin implements BeaconConsumer {
         beaconManager.setForegroundBetweenScanPeriod(0L); // Continuous scanning in foreground
         beaconManager.setForegroundScanPeriod(1100L); // Standard scan period
 
-        // Bind to beacon service
-        beaconManager.bind(this);
+        // bind() is deferred to bindIfNeeded().
 
         // Set up monitoring and ranging notifiers
         beaconManager.addMonitorNotifier(
@@ -179,6 +178,7 @@ public class CapacitorIbeaconPlugin extends Plugin implements BeaconConsumer {
             if (enableBackgroundMode != null) {
                 setBackgroundModeEnabled(enableBackgroundMode);
             }
+            bindIfNeeded();
             Region region = createRegion(identifier, uuid, major, minor);
             monitoredRegions.put(identifier, region);
             beaconManager.startMonitoring(region);
@@ -227,6 +227,7 @@ public class CapacitorIbeaconPlugin extends Plugin implements BeaconConsumer {
             if (enableBackgroundMode != null) {
                 setBackgroundModeEnabled(enableBackgroundMode);
             }
+            bindIfNeeded();
             Region region = createRegion(identifier, uuid, major, minor);
             rangedRegions.put(identifier, region);
             beaconManager.startRangingBeacons(region);
@@ -567,8 +568,16 @@ public class CapacitorIbeaconPlugin extends Plugin implements BeaconConsumer {
     @PluginMethod
     public void enableBackgroundMode(PluginCall call) {
         Boolean enabled = call.getBoolean("enabled", true);
-        setBackgroundModeEnabled(enabled != null && enabled);
-        call.resolve();
+        boolean wantBackground = enabled != null && enabled;
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && wantBackground != foregroundServiceEnabled) {
+                reconfigureForegroundService(wantBackground);
+            }
+            setBackgroundModeEnabled(wantBackground);
+            call.resolve();
+        } catch (Exception e) {
+            call.reject("Failed to enable background mode", e);
+        }
     }
 
     @PluginMethod
@@ -703,6 +712,16 @@ public class CapacitorIbeaconPlugin extends Plugin implements BeaconConsumer {
         }
     }
 
+    private void bindIfNeeded() {
+        if (beaconManagerBound || beaconManager == null) {
+            return;
+        }
+        if (backgroundModeEnabled) {
+            enableForegroundServiceIfNeeded();
+        }
+        beaconManager.bind(this);
+    }
+
     private void setBackgroundModeEnabled(boolean enabled) {
         backgroundModeEnabled = enabled;
         applyBackgroundMode(enabled);
@@ -712,15 +731,30 @@ public class CapacitorIbeaconPlugin extends Plugin implements BeaconConsumer {
         if (beaconManager == null) {
             return;
         }
+        beaconManager.setBackgroundMode(enabled && isInBackground);
+    }
 
-        boolean shouldEnableBackgroundMode = enabled && isInBackground;
-
-        if (shouldEnableBackgroundMode) {
+    // enableForegroundServiceScanning()/disableForegroundServiceScanning() may only be called
+    // while unbound. Re-registers any regions that were actively monitored/ranged before the cycle.
+    private void reconfigureForegroundService(boolean wantForegroundService) {
+        boolean wasBound = beaconManagerBound;
+        if (wasBound) {
+            beaconManager.unbind(this);
+            beaconManagerBound = false;
+        }
+        if (wantForegroundService) {
             enableForegroundServiceIfNeeded();
-            beaconManager.setBackgroundMode(true);
         } else {
             disableForegroundServiceIfNeeded();
-            beaconManager.setBackgroundMode(false);
+        }
+        if (wasBound) {
+            beaconManager.bind(this);
+            for (Region region : monitoredRegions.values()) {
+                beaconManager.startMonitoring(region);
+            }
+            for (Region region : rangedRegions.values()) {
+                beaconManager.startRangingBeacons(region);
+            }
         }
     }
 

--- a/android/src/main/java/ee/forgr/plugin/capacitor_ibeacon/CapacitorIbeaconPlugin.java
+++ b/android/src/main/java/ee/forgr/plugin/capacitor_ibeacon/CapacitorIbeaconPlugin.java
@@ -570,7 +570,10 @@ public class CapacitorIbeaconPlugin extends Plugin implements BeaconConsumer {
         Boolean enabled = call.getBoolean("enabled", true);
         boolean wantBackground = enabled != null && enabled;
         try {
-            ensureForegroundServiceMatches(wantBackground);
+            if (!ensureForegroundServiceMatches(wantBackground)) {
+                call.reject("Failed to enable foreground service scanning");
+                return;
+            }
             setBackgroundModeEnabled(wantBackground);
             call.resolve();
         } catch (Exception e) {
@@ -735,22 +738,24 @@ public class CapacitorIbeaconPlugin extends Plugin implements BeaconConsumer {
 
     // Covers both a fresh bind and a later call (e.g. a per-region enableBackgroundMode option)
     // that raises the requirement while already bound.
-    private void ensureForegroundServiceMatches(boolean wantForegroundService) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && wantForegroundService != foregroundServiceEnabled) {
-            reconfigureForegroundService(wantForegroundService);
+    private boolean ensureForegroundServiceMatches(boolean wantForegroundService) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O || wantForegroundService == foregroundServiceEnabled) {
+            return true;
         }
+        return reconfigureForegroundService(wantForegroundService);
     }
 
     // enableForegroundServiceScanning()/disableForegroundServiceScanning() may only be called
     // while unbound. Re-registers any regions that were actively monitored/ranged before the cycle.
-    private void reconfigureForegroundService(boolean wantForegroundService) {
+    private boolean reconfigureForegroundService(boolean wantForegroundService) {
         boolean wasBound = beaconManagerBound;
         if (wasBound) {
             beaconManager.unbind(this);
             beaconManagerBound = false;
         }
+        boolean success = true;
         if (wantForegroundService) {
-            enableForegroundServiceIfNeeded();
+            success = enableForegroundServiceIfNeeded();
         } else {
             disableForegroundServiceIfNeeded();
         }
@@ -764,6 +769,7 @@ public class CapacitorIbeaconPlugin extends Plugin implements BeaconConsumer {
                 beaconManager.startRangingBeacons(region);
             }
         }
+        return success;
     }
 
     private boolean enableForegroundServiceIfNeeded() {


### PR DESCRIPTION
`load()` calls `beaconManager.bind(this)` unconditionally at plugin startup, before any permission or background-mode decision exists. `enableForegroundServiceScanning()`/`disableForegroundServiceScanning()` both require being called before the *first* bind — calling either afterward throws `IllegalStateException: May not be called after consumers are already bound`. Since `bind()` always already happened by the time any app code runs, both calls were permanently "too late" for the entire lifetime of the app.

406d483 caught the resulting exception (best-effort `try`/`catch` around `enableForegroundServiceScanning()`) so it no longer crashes, but that only masks the symptom — `enableForegroundServiceScanning()` still always fails, so background-mode scanning silently never actually gets configured, regardless of when or how a consumer calls `enableBackgroundMode()`. `#21`'s "no detection at all" / "fails to enable background mode" reports match this exactly.

Verified against a minimal repro: https://github.com/gion-andri/capacitor-ibeacon-background-mode-crash-repro (reproduces the failure on `main` against the published `8.1.32`; this branch fixes it when swapped in via a `file:` dependency — same repro app, no other changes needed).

## Fix

`bind()` is deferred into a new `bindIfNeeded()`, called lazily from `startMonitoringForRegion`/`startRangingBeaconsInRegion` instead of `load()`. Two cases:

**1. Background mode declared before the first bind** (plugin config, or the region's `enableBackgroundMode` option, passed inline to the same call that starts scanning) — `bindIfNeeded()` sees `backgroundModeEnabled` already set and configures `enableForegroundServiceIfNeeded()` before calling `bind()`. Ordering constraint satisfied, no exception, works on the first try.

Deliberately conditional, not unconditional: `enableForegroundServiceScanning()`'s configured notification gets shown by `BeaconService.onCreate()` → `startForegroundIfConfigured()` the moment the service actually starts, independent of `setBackgroundMode()`'s value. Configuring it unconditionally on every first bind would mean every app using this plugin gets a persistent notification the instant scanning starts, even ones that only ever want plain foreground ranging. Gating on `backgroundModeEnabled` avoids that.

**2. `enableBackgroundMode()` called standalone, after scanning has already started** — the pattern `#21`'s own report uses, and the one 406d483 couldn't actually fix (only stopped it from crashing). At this point `bind()` has already happened, so `enableForegroundServiceScanning()`/`disableForegroundServiceScanning()` can't be called directly — [`disableForegroundServiceScanning()`'s own doc comment](https://github.com/AltBeacon/android-beacon-library/blob/aca69f9bc7f3526032e6e5fcc3593a3259c7d2d4/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java#L2032-L2038) is explicit that changing this requires a full unbind → reconfigure → rebind cycle. `enableBackgroundMode()` now does exactly that via `reconfigureForegroundService()`: unbind, enable/disable as requested, rebind, and re-register whatever was in `monitoredRegions`/`rangedRegions` before the cycle (plugin-level state already tracked, nothing new required from the JS caller). Only runs when there's an actual change to make (`wantBackground != foregroundServiceEnabled`), so redundant calls are cheap no-ops.

`applyBackgroundMode()` no longer touches `enableForegroundServiceIfNeeded()`/`disableForegroundServiceIfNeeded()` at all. It runs on every `handleOnPause()`/`handleOnResume()`/`setBackgroundModeEnabled()` call, which is fundamentally incompatible with the once-only, pre-bind-only foreground-service configuration — `disableForegroundServiceScanning()` has the identical "before first bind" restriction as `enableForegroundServiceScanning()`, so calling either from a method that runs on every pause/resume was never safe once bound. `applyBackgroundMode()` is left with just the one thing that's always safe to call regardless of bind state: `beaconManager.setBackgroundMode(enabled && isInBackground)`.

## Testing

- `bun run check:wiring`, `bun run verify:android` (`gradlew clean build test`), `bun run lint` (eslint/prettier/swiftlint) — all pass.
- On-device (Pixel 9a, API 37): confirmed the original crash (`enableBackgroundMode()` called after scanning starts → `handleOnPause()` → `IllegalStateException`) is gone, and the fixed path logs `successfully started foreground beacon scanning service` where it previously threw.
- Confirmed `bindIfNeeded()`/`reconfigureForegroundService()` each only call `bind()`/`unbind()`/`startMonitoring()`/`startRangingBeacons()` exactly once per invocation (traced with temporary logging, since AltBeacon's own `bindInternal()` log lines appeared twice per rebind in logcat — confirmed that's internal to AltBeacon's own scheduled-jobs→foreground-service transition, not a double-call from this fix).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-ibeacon/pull/47?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved beacon monitoring and ranging startup reliability by initializing services only when needed.
  * Enhanced background-mode handling and foreground-service transitions on supported Android versions.
  * Preserved active monitoring and ranging regions when background scanning settings change.
  * Added clearer error handling when background mode cannot be enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->