### PR TITLE
fix(android): push updated scan periods to the running service in setBackgroundScanPeriod

### DIFF
--- a/android/src/main/java/ee/forgr/plugin/capacitor_ibeacon/CapacitorIbeaconPlugin.java
+++ b/android/src/main/java/ee/forgr/plugin/capacitor_ibeacon/CapacitorIbeaconPlugin.java
@@ -579,6 +579,9 @@ public class CapacitorIbeaconPlugin extends Plugin implements BeaconConsumer {
         try {
             beaconManager.setBackgroundScanPeriod(scanPeriod);
             beaconManager.setBackgroundBetweenScanPeriod(betweenScanPeriod);
+            if (beaconManagerBound) {
+                beaconManager.updateScanPeriods();
+            }
             call.resolve();
         } catch (Exception e) {
             call.reject("Failed to set background scan period", e);


### PR DESCRIPTION
`BeaconManager.setBackgroundScanPeriod()`/`setBackgroundBetweenScanPeriod()` are pure field assignments. [The library's own doc comment on `setBackgroundScanPeriod`](https://github.com/AltBeacon/android-beacon-library/blob/aca69f9bc7f3526032e6e5fcc3593a3259c7d2d4/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java#L379-L385) states explicitly: *"This function is used to setup the period before calling `bind()` or when switching between background/foreground. To have it effect on an already running scan (when the next cycle starts), call `updateScanPeriods`."*

The plugin's `setBackgroundScanPeriod` method never makes that follow-up call. Calling it on an already-running scan silently has no effect until some unrelated later trigger happens to sync it — `BeaconManager.setBackgroundMode()` calls `updateScanPeriods()` internally, but only when the foreground/background state actually flips, not on request. The call itself still resolves successfully, which is what makes this easy to miss — nothing signals that the requested period never took effect.

## Fix

```java
beaconManager.setBackgroundScanPeriod(scanPeriod);
beaconManager.setBackgroundBetweenScanPeriod(betweenScanPeriod);
if (beaconManagerBound) {
    beaconManager.updateScanPeriods();
}
```
Guarded on `beaconManagerBound` since `updateScanPeriods()` already no-ops safely on its own (`if (isAnyConsumerBound()) { ... }`) when nothing is bound yet — matching the plugin's existing use of that field elsewhere.

## Testing

`bun run check:wiring`, `bun run verify:android` (`gradlew clean build test`), `bun run lint` (eslint/prettier/swiftlint) — all pass. No live on-device repro included: the bug is an absent method call, not a runtime misbehavior, so there's nothing additional a live demo would show beyond the diff itself and the library's documented contract linked above.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-ibeacon/pull/48?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated background scan timing immediately when scanning is active, ensuring new scan intervals take effect without restarting the beacon service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->