### PR TITLE
fix(ios): lazily construct CBPeripheralManager

### DIFF
--- a/ios/Sources/CapacitorIbeaconPlugin/CapacitorIbeacon.swift
+++ b/ios/Sources/CapacitorIbeaconPlugin/CapacitorIbeacon.swift
@@ -13,11 +13,23 @@ public class CapacitorIbeacon: NSObject, CLLocationManagerDelegate, CBPeripheral
         super.init()
         locationManager = CLLocationManager()
         locationManager.delegate = self
-        peripheralManager = CBPeripheralManager(delegate: self, queue: nil)
+        // peripheralManager intentionally not constructed here - see ensurePeripheralManager().
     }
 
     public func setPlugin(_ plugin: CapacitorIbeaconPlugin) {
         self.plugin = plugin
+    }
+
+    // Merely instantiating CBPeripheralManager triggers the system Bluetooth permission prompt,
+    // independent of any method actually being called on it. Only startAdvertising/
+    // stopAdvertising/isBluetoothEnabled need it, so defer construction until one of them
+    // actually runs, instead of doing it unconditionally in init() - which otherwise fires the
+    // prompt at app launch, before any of this plugin's own JS API has been touched.
+    private func ensurePeripheralManager() -> CBPeripheralManager {
+        if peripheralManager == nil {
+            peripheralManager = CBPeripheralManager(delegate: self, queue: nil)
+        }
+        return peripheralManager
     }
 
     public func startMonitoringForRegion(identifier: String, uuid: String, major: Int?, minor: Int?, completion: @escaping (Result<Void, Error>) -> Void) {
@@ -91,16 +103,18 @@ public class CapacitorIbeacon: NSObject, CLLocationManagerDelegate, CBPeripheral
         let beaconRegion = CLBeaconRegion(uuid: beaconUUID, major: CLBeaconMajorValue(major), minor: CLBeaconMinorValue(minor), identifier: identifier)
 
         if let power = measuredPower {
-            peripheralManager.startAdvertising(beaconRegion.peripheralData(withMeasuredPower: NSNumber(value: power)) as? [String: Any])
+            ensurePeripheralManager().startAdvertising(beaconRegion.peripheralData(withMeasuredPower: NSNumber(value: power)) as? [String: Any])
         } else {
-            peripheralManager.startAdvertising(beaconRegion.peripheralData(withMeasuredPower: nil) as? [String: Any])
+            ensurePeripheralManager().startAdvertising(beaconRegion.peripheralData(withMeasuredPower: nil) as? [String: Any])
         }
 
         completion(.success(()))
     }
 
     public func stopAdvertising() {
-        peripheralManager.stopAdvertising()
+        // Not ensurePeripheralManager(): stopping something that was never started shouldn't
+        // newly construct (and trigger a permission prompt for) a manager that doesn't exist yet.
+        peripheralManager?.stopAdvertising()
     }
 
     public func requestWhenInUseAuthorization() {
@@ -130,7 +144,7 @@ public class CapacitorIbeacon: NSObject, CLLocationManagerDelegate, CBPeripheral
     }
 
     public func isBluetoothEnabled() -> Bool {
-        return peripheralManager.state == .poweredOn
+        return ensurePeripheralManager().state == .poweredOn
     }
 
     public func isRangingAvailable() -> Bool {

--- a/ios/Sources/CapacitorIbeaconPlugin/CapacitorIbeacon.swift
+++ b/ios/Sources/CapacitorIbeaconPlugin/CapacitorIbeacon.swift
@@ -8,28 +8,42 @@ public class CapacitorIbeacon: NSObject, CLLocationManagerDelegate, CBPeripheral
     private weak var plugin: CapacitorIbeaconPlugin?
     private var monitoredRegions: [String: CLBeaconRegion] = [:]
     private var rangedRegions: [String: CLBeaconRegion] = [:]
+    private var peripheralManagerReadyCallbacks: [(CBPeripheralManager) -> Void] = []
+    private let peripheralManagerStateTimeout: TimeInterval = 3.0
 
     override public init() {
         super.init()
         locationManager = CLLocationManager()
         locationManager.delegate = self
-        // peripheralManager intentionally not constructed here - see ensurePeripheralManager().
+        // peripheralManager intentionally not constructed here - see withReadyPeripheralManager().
     }
 
     public func setPlugin(_ plugin: CapacitorIbeaconPlugin) {
         self.plugin = plugin
     }
 
-    // Merely instantiating CBPeripheralManager triggers the system Bluetooth permission prompt,
-    // independent of any method actually being called on it. Only startAdvertising/
-    // stopAdvertising/isBluetoothEnabled need it, so defer construction until one of them
-    // actually runs, instead of doing it unconditionally in init() - which otherwise fires the
-    // prompt at app launch, before any of this plugin's own JS API has been touched.
-    private func ensurePeripheralManager() -> CBPeripheralManager {
+    // Merely instantiating CBPeripheralManager triggers the Bluetooth permission prompt, so
+    // construction is deferred to here rather than init(). Its state also starts .unknown and
+    // only settles asynchronously via peripheralManagerDidUpdateState() below, so `body` waits
+    // for that instead of seeing a stale .unknown - with a timeout in case it never settles.
+    private func withReadyPeripheralManager(_ body: @escaping (CBPeripheralManager) -> Void) {
         if peripheralManager == nil {
             peripheralManager = CBPeripheralManager(delegate: self, queue: nil)
         }
-        return peripheralManager
+
+        if peripheralManager.state != .unknown {
+            body(peripheralManager)
+            return
+        }
+
+        peripheralManagerReadyCallbacks.append(body)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + peripheralManagerStateTimeout) { [weak self] in
+            guard let self = self, !self.peripheralManagerReadyCallbacks.isEmpty else { return }
+            let callbacks = self.peripheralManagerReadyCallbacks
+            self.peripheralManagerReadyCallbacks.removeAll()
+            callbacks.forEach { $0(self.peripheralManager) }
+        }
     }
 
     public func startMonitoringForRegion(identifier: String, uuid: String, major: Int?, minor: Int?, completion: @escaping (Result<Void, Error>) -> Void) {
@@ -102,13 +116,21 @@ public class CapacitorIbeacon: NSObject, CLLocationManagerDelegate, CBPeripheral
 
         let beaconRegion = CLBeaconRegion(uuid: beaconUUID, major: CLBeaconMajorValue(major), minor: CLBeaconMinorValue(minor), identifier: identifier)
 
-        if let power = measuredPower {
-            ensurePeripheralManager().startAdvertising(beaconRegion.peripheralData(withMeasuredPower: NSNumber(value: power)) as? [String: Any])
-        } else {
-            ensurePeripheralManager().startAdvertising(beaconRegion.peripheralData(withMeasuredPower: nil) as? [String: Any])
-        }
+        withReadyPeripheralManager { manager in
+            guard manager.state == .poweredOn else {
+                let error = NSError(domain: "CapacitorIbeacon", code: -2, userInfo: [NSLocalizedDescriptionKey: "Bluetooth is not powered on"])
+                completion(.failure(error))
+                return
+            }
 
-        completion(.success(()))
+            if let power = measuredPower {
+                manager.startAdvertising(beaconRegion.peripheralData(withMeasuredPower: NSNumber(value: power)) as? [String: Any])
+            } else {
+                manager.startAdvertising(beaconRegion.peripheralData(withMeasuredPower: nil) as? [String: Any])
+            }
+
+            completion(.success(()))
+        }
     }
 
     public func stopAdvertising() {
@@ -143,8 +165,10 @@ public class CapacitorIbeacon: NSObject, CLLocationManagerDelegate, CBPeripheral
         }
     }
 
-    public func isBluetoothEnabled() -> Bool {
-        return ensurePeripheralManager().state == .poweredOn
+    public func isBluetoothEnabled(completion: @escaping (Bool) -> Void) {
+        withReadyPeripheralManager { manager in
+            completion(manager.state == .poweredOn)
+        }
     }
 
     public func isRangingAvailable() -> Bool {
@@ -243,6 +267,11 @@ public class CapacitorIbeacon: NSObject, CLLocationManagerDelegate, CBPeripheral
     // MARK: - CBPeripheralManagerDelegate
 
     public func peripheralManagerDidUpdateState(_ peripheral: CBPeripheralManager) {
-        // Handle Bluetooth state changes if needed
+        guard !peripheralManagerReadyCallbacks.isEmpty else {
+            return
+        }
+        let callbacks = peripheralManagerReadyCallbacks
+        peripheralManagerReadyCallbacks.removeAll()
+        callbacks.forEach { $0(peripheral) }
     }
 }

--- a/ios/Sources/CapacitorIbeaconPlugin/CapacitorIbeaconPlugin.swift
+++ b/ios/Sources/CapacitorIbeaconPlugin/CapacitorIbeaconPlugin.swift
@@ -144,8 +144,9 @@ public class CapacitorIbeaconPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     @objc func isBluetoothEnabled(_ call: CAPPluginCall) {
-        let enabled = implementation.isBluetoothEnabled()
-        call.resolve(["enabled": enabled])
+        implementation.isBluetoothEnabled { enabled in
+            call.resolve(["enabled": enabled])
+        }
     }
 
     @objc func isRangingAvailable(_ call: CAPPluginCall) {


### PR DESCRIPTION
`CapacitorIbeacon.init()` constructs `CBPeripheralManager` unconditionally at plugin load — before any permission decision or JS call. On iOS, merely instantiating `CBPeripheralManager`/`CBCentralManager` triggers the system Bluetooth permission prompt, independent of any method actually being called on it. So this prompt fires at app launch, before the app has shown a single screen, for a permission most consumers never actually need — `startAdvertising()`/`stopAdvertising()`/`isBluetoothEnabled()` are the only methods that touch `peripheralManager` at all; ranging/monitoring goes entirely through `CLLocationManager`, gated by Location permission instead.

Confirmed on-device with a minimal repro [(`capacitor-ibeacon-ios-bluetooth-prompt-at-launch-repro`)](https://github.com/gion-andri/capacitor-ibeacon-ios-bluetooth-prompt-at-launch-repro): on a fresh install, the alert appears immediately at launch with this branch's parent commit, and is gone with this fix applied.

## Fix

Defer construction to `ensurePeripheralManager()`, called only where it's actually needed:
```swift
private func ensurePeripheralManager() -> CBPeripheralManager {
    if peripheralManager == nil {
        peripheralManager = CBPeripheralManager(delegate: self, queue: nil)
    }
    return peripheralManager
}
```
Used from `startAdvertising()` and `isBluetoothEnabled()` — both a deliberate action/query that reasonably justifies triggering the prompt if/when a consumer actually calls them. `stopAdvertising()` deliberately does **not** use it (`peripheralManager?.stopAdvertising()` instead) — stopping something that was never started shouldn't itself force a fresh permission prompt for a manager that doesn't exist yet.

## Testing

- `bun run check:wiring`, `bun run verify:ios` (`xcodebuild -scheme CapgoCapacitorIbeacon`), `bun run lint` — all pass, no new warnings.
- On-device: confirmed no permission prompt at launch, and confirmed the deferred path still works correctly - calling `isBluetoothEnabled()` after launch correctly triggers the prompt and returns a real result once the manager's state settles.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-ibeacon/pull/49?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluetooth advertising startup by initializing the Bluetooth manager only when needed.
  * Prevented unnecessary Bluetooth manager creation when stopping advertising that was never started.
  * Improved Bluetooth availability checks for more reliable state reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->