### PR TITLE
fix(android): read scan periods with optLong for Integer bridge values

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation 'org.altbeacon:android-beacon-library:2.21.2'
     testImplementation "junit:junit:$junitVersion"
+    testImplementation "org.json:json:20240303"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
 }

--- a/android/src/main/java/ee/forgr/plugin/capacitor_ibeacon/CapacitorIbeaconPlugin.java
+++ b/android/src/main/java/ee/forgr/plugin/capacitor_ibeacon/CapacitorIbeaconPlugin.java
@@ -583,8 +583,8 @@ public class CapacitorIbeaconPlugin extends Plugin implements BeaconConsumer {
 
     @PluginMethod
     public void setBackgroundScanPeriod(PluginCall call) {
-        Long scanPeriod = call.getLong("scanPeriod", 10000L);
-        Long betweenScanPeriod = call.getLong("betweenScanPeriod", 15000L);
+        long scanPeriod = longOptionFromCall(call, "scanPeriod", 10000L);
+        long betweenScanPeriod = longOptionFromCall(call, "betweenScanPeriod", 15000L);
 
         try {
             beaconManager.setBackgroundScanPeriod(scanPeriod);
@@ -610,6 +610,12 @@ public class CapacitorIbeaconPlugin extends Plugin implements BeaconConsumer {
     }
 
     // Helper methods
+
+    // Capacitor's PluginCall.getLong() only reads Java Long values. JS numbers that
+    // fit in 32 bits cross the bridge as Integer, so optLong is required.
+    static long longOptionFromCall(PluginCall call, String key, long defaultValue) {
+        return call.getData().optLong(key, defaultValue);
+    }
 
     private boolean hasBluetoothPermissions() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {

--- a/android/src/test/java/ee/forgr/plugin/capacitor_ibeacon/CapacitorIbeaconPluginUnitTest.java
+++ b/android/src/test/java/ee/forgr/plugin/capacitor_ibeacon/CapacitorIbeaconPluginUnitTest.java
@@ -27,16 +27,8 @@ public class CapacitorIbeaconPluginUnitTest {
             15000L,
             CapacitorIbeaconPlugin.longOptionFromCall(call, "betweenScanPeriod", 7000L)
         );
-        assertEquals(
-            "PluginCall.getLong misses Integer bridge values",
-            Long.valueOf(5000L),
-            call.getLong("scanPeriod", 5000L)
-        );
-        assertEquals(
-            "PluginCall.getLong misses Integer bridge values",
-            Long.valueOf(7000L),
-            call.getLong("betweenScanPeriod", 7000L)
-        );
+        assertEquals("PluginCall.getLong misses Integer bridge values", Long.valueOf(5000L), call.getLong("scanPeriod", 5000L));
+        assertEquals("PluginCall.getLong misses Integer bridge values", Long.valueOf(7000L), call.getLong("betweenScanPeriod", 7000L));
     }
 
     @Test

--- a/android/src/test/java/ee/forgr/plugin/capacitor_ibeacon/CapacitorIbeaconPluginUnitTest.java
+++ b/android/src/test/java/ee/forgr/plugin/capacitor_ibeacon/CapacitorIbeaconPluginUnitTest.java
@@ -1,0 +1,49 @@
+package ee.forgr.plugin.capacitor_ibeacon;
+
+import static org.junit.Assert.assertEquals;
+
+import com.getcapacitor.JSObject;
+import com.getcapacitor.PluginCall;
+import org.json.JSONException;
+import org.junit.Test;
+
+public class CapacitorIbeaconPluginUnitTest {
+
+    @Test
+    public void testLongOptionFromCallCoercesIntegerBridgeValue() throws JSONException {
+        JSObject data = new JSObject();
+        data.put("scanPeriod", 10000);
+        data.put("betweenScanPeriod", 15000);
+
+        PluginCall call = new PluginCall(null, "CapacitorIbeacon", "test-callback", "setBackgroundScanPeriod", data);
+
+        assertEquals(
+            "JS numbers within Integer range must be read as scanPeriod",
+            10000L,
+            CapacitorIbeaconPlugin.longOptionFromCall(call, "scanPeriod", 5000L)
+        );
+        assertEquals(
+            "JS numbers within Integer range must be read as betweenScanPeriod",
+            15000L,
+            CapacitorIbeaconPlugin.longOptionFromCall(call, "betweenScanPeriod", 7000L)
+        );
+        assertEquals(
+            "PluginCall.getLong misses Integer bridge values",
+            Long.valueOf(5000L),
+            call.getLong("scanPeriod", 5000L)
+        );
+        assertEquals(
+            "PluginCall.getLong misses Integer bridge values",
+            Long.valueOf(7000L),
+            call.getLong("betweenScanPeriod", 7000L)
+        );
+    }
+
+    @Test
+    public void testLongOptionFromCallUsesDefaultWhenMissing() {
+        PluginCall call = new PluginCall(null, "CapacitorIbeacon", "test-callback", "setBackgroundScanPeriod", new JSObject());
+
+        assertEquals(10000L, CapacitorIbeaconPlugin.longOptionFromCall(call, "scanPeriod", 10000L));
+        assertEquals(15000L, CapacitorIbeaconPlugin.longOptionFromCall(call, "betweenScanPeriod", 15000L));
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Read `scanPeriod` and `betweenScanPeriod` on Android via `call.getData().optLong()` instead of `PluginCall.getLong()`.
- Add regression unit tests for the Integer bridge-value case.
- Add `org.json:json` as a test dependency so JVM unit tests can exercise real JSON coercion.

## Why
- Typical JS numbers (e.g. `scanPeriod: 10000`, `betweenScanPeriod: 15000`) cross the Capacitor bridge as `org.json` `Integer` values.
- Capacitor 8 `PluginCall.getLong()` only returns values that are already Java `Long` instances, so realistic scan-period options were always read as the plugin defaults (10000/15000) even when callers passed different values — or silently ignored custom values that fit in 32 bits.
- Same class of bug as [capacitor-background-geolocation#62](https://github.com/Cap-go/capacitor-background-geolocation/issues/62) / [PR #64](https://github.com/Cap-go/capacitor-background-geolocation/pull/64).

## How
- Added `longOptionFromCall()` helper that uses `optLong()` (coerces Integer/Long/Double).
- Audited all `call.getLong(...)` usages in the plugin: only `setBackgroundScanPeriod` used it.
- Audited `call.getInt(...)` for JS options (`major`, `minor`): `PluginCall.getInt()` already accepts `Integer` bridge values; no change needed.
- iOS is unaffected (Swift/NSNumber path).

## Testing
- `./gradlew test` (Android unit tests), including new regression tests:
  - `testLongOptionFromCallCoercesIntegerBridgeValue` — verifies `10000`/`15000` Integer bridge values are read correctly and documents that `PluginCall.getLong()` returns the default.
  - `testLongOptionFromCallUsesDefaultWhenMissing` — verifies default handling when options are absent.

## Not Tested
- On-device Android integration with live BLE scanning. The root cause and fix path are covered by unit tests and match Capacitor's `PluginCall.getLong()` implementation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c1f447f-a861-45cb-8ddf-54da0c0f970e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c1f447f-a861-45cb-8ddf-54da0c0f970e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-ibeacon/pr/52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789217236&installation_model_id=430928&pr_number=52&repository=Cap-go%2Fcapacitor-ibeacon&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-ibeacon%2Fpull%2F52&signature=f8d059fc682fa183333b9b984307f29ad61d6fe5c19fd1a4efd806065b9686b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-ibeacon/pull/52?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

